### PR TITLE
Fix Gradle build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See live demo: [pay.cards](https://play.google.com/store/apps/details?id=cards.p
 
     ```gradle
     repositories {
-         maven { url "http://pay.cards/maven" }
+         maven { url "https://pay.cards/maven" }
     }
     ```
 


### PR DESCRIPTION
On newer gradles, the build system doesn't accept insecure protocol.